### PR TITLE
Nested json

### DIFF
--- a/Sources/Encodable.swift
+++ b/Sources/Encodable.swift
@@ -25,6 +25,12 @@ extension String: Encodable {
     }
 }
 
+extension NSString: Encodable {
+    public func encode() throws -> JSON {
+        return .STRING(self as String)
+    }
+}
+
 extension Bool: Encodable {
     public func encode() throws -> JSON {
         return .BOOL(self)
@@ -38,6 +44,12 @@ public protocol Number: Encodable {
 extension Number {
     public func encode() throws -> JSON {
         return .NUMBER(self)
+    }
+}
+
+extension NSNumber: Number {
+    public func asObject() -> AnyObject {
+        return self
     }
 }
 

--- a/Sources/Encodable.swift
+++ b/Sources/Encodable.swift
@@ -25,12 +25,6 @@ extension String: Encodable {
     }
 }
 
-extension NSString: Encodable {
-    public func encode() throws -> JSON {
-        return .STRING(self as String)
-    }
-}
-
 extension Bool: Encodable {
     public func encode() throws -> JSON {
         return .BOOL(self)
@@ -44,12 +38,6 @@ public protocol Number: Encodable {
 extension Number {
     public func encode() throws -> JSON {
         return .NUMBER(self)
-    }
-}
-
-extension NSNumber: Number {
-    public func asObject() -> AnyObject {
-        return self
     }
 }
 

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -13,8 +13,8 @@ public enum JSON {
     case BOOL(Bool)
     case STRING(String)
     case NUMBER(Number)
-    case ARRAY([AnyObject])
-    case DICTIONARY([String: AnyObject])
+    case ARRAY([JSON])
+    case DICTIONARY([String: JSON])
     
     public func asObject() -> AnyObject {
         switch self {
@@ -27,9 +27,9 @@ public enum JSON {
         case .NUMBER(let number):
             return number.asObject()
         case .ARRAY(let array):
-            return array
+            return array.map { $0.asObject() }
         case .DICTIONARY(let dictionary):
-            return dictionary
+            return convert(dictionary.map { ($0, $1.asObject()) })
         }
     }
     

--- a/Tests/EncoderTests.swift
+++ b/Tests/EncoderTests.swift
@@ -14,7 +14,7 @@ class EncoderTests: XCTestCase {
     func testStandardEncodable() {
         do {
             let object = StandardEncodables()
-            guard case .DICTIONARY(let json) = try encode(object) else {
+            guard let json = try encode(object).asObject() as? [String: AnyObject] else {
                 XCTFail()
                 return
             }
@@ -54,13 +54,13 @@ class EncoderTests: XCTestCase {
             }
             XCTAssertEqual(string, object.customValue())
 
-            guard case .ARRAY(let array) = try encode([object]) else {
+            guard let array = try encode([object]).asObject() as? [AnyObject] else {
                 XCTFail()
                 return
             }
             XCTAssertEqual(array as! [String], [object.customValue()])
 
-            guard case .DICTIONARY(let dictionary) = try encode(["value": object]) else {
+            guard let dictionary = try encode(["value": object]).asObject() as? [String: AnyObject] else {
                 XCTFail()
                 return
             }


### PR DESCRIPTION
Can define broken encode method in Encodable if set AnyObject in JSON.ARRAY.
Changing type is necesarry for more safety Encodable.
