### PR TITLE
Enum sytnax sugar

### DIFF
--- a/Sources/Encodable.swift
+++ b/Sources/Encodable.swift
@@ -18,7 +18,7 @@ extension Encodable {
         return try _encode(object)
     }
     
-    // Syntax suger for Enum
+    // Syntax sugar for Enum
     public func encode(f: () -> Any?) throws -> JSON {
         return try _encode(f())
     }

--- a/Sources/Encodable.swift
+++ b/Sources/Encodable.swift
@@ -17,6 +17,11 @@ extension Encodable {
     public func encode(object: Any?) throws -> JSON {
         return try _encode(object)
     }
+    
+    // Syntax suger for Enum
+    public func encode(f: () -> Any?) throws -> JSON {
+        return try _encode(f())
+    }
 }
 
 extension String: Encodable {


### PR DESCRIPTION
Adding new syntax sugar for enum.
If you encode enum value, you should use switch.
The new syntax sugar support your encode with switch.

``` swift
return try encode {
  switch self {
    case A:
      return "A"
    case B:
      ...
  }
}
```
