### PR TITLE
[proposal] Support encode from Swift.Encodable to Illuso.Encodable

### DIFF
--- a/Illuso.xcodeproj/project.pbxproj
+++ b/Illuso.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		56D29E121FBABA87009D9439 /* Encodable+Swift.Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D29E111FBABA87009D9439 /* Encodable+Swift.Encodable.swift */; };
 		D2601EBD1E90D668009951C6 /* Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2601EB81E90D668009951C6 /* Encodable.swift */; };
 		D2601EBE1E90D668009951C6 /* Encoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2601EB91E90D668009951C6 /* Encoder.swift */; };
 		D2601EBF1E90D668009951C6 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2601EBA1E90D668009951C6 /* Error.swift */; };
@@ -28,6 +29,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		56D29E111FBABA87009D9439 /* Encodable+Swift.Encodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+Swift.Encodable.swift"; sourceTree = "<group>"; };
 		D2601EB81E90D668009951C6 /* Encodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Encodable.swift; sourceTree = "<group>"; };
 		D2601EB91E90D668009951C6 /* Encoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Encoder.swift; sourceTree = "<group>"; };
 		D2601EBA1E90D668009951C6 /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -93,6 +95,7 @@
 			isa = PBXGroup;
 			children = (
 				D2601EB81E90D668009951C6 /* Encodable.swift */,
+				56D29E111FBABA87009D9439 /* Encodable+Swift.Encodable.swift */,
 				D2601EB91E90D668009951C6 /* Encoder.swift */,
 				D2601EBA1E90D668009951C6 /* Error.swift */,
 				D2601EBB1E90D668009951C6 /* JSON.swift */,
@@ -180,6 +183,7 @@
 				D2601EBF1E90D668009951C6 /* Error.swift in Sources */,
 				D2601EC01E90D668009951C6 /* JSON.swift in Sources */,
 				D2601EC11E90D668009951C6 /* RawRepresentable.swift in Sources */,
+				56D29E121FBABA87009D9439 /* Encodable+Swift.Encodable.swift in Sources */,
 				D2601EBD1E90D668009951C6 /* Encodable.swift in Sources */,
 				D2601EBE1E90D668009951C6 /* Encoder.swift in Sources */,
 			);

--- a/Sources/Encodable+Swift.Encodable.swift
+++ b/Sources/Encodable+Swift.Encodable.swift
@@ -1,0 +1,26 @@
+//
+//  Encodable+Swift.Encodable.swift
+//  Illuso
+//
+//  Created by ST20591 on 2017/11/14.
+//
+
+import Foundation
+
+public extension Swift.Encodable {
+    func encodeToDictionary() throws -> [String: Any] {
+        let data = try JSONEncoder().encode(self)
+        let jsonObject = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
+        guard let dictionary = jsonObject as? [String: Any] else {
+            throw JSONError.unknown
+        }
+        return dictionary
+    }
+}
+
+public extension Illuso.Encodable where Self: Swift.Encodable {
+    func encode() throws -> JSON {
+        return try encode(encodeToDictionary())
+    }
+}
+

--- a/Sources/Encodable.swift
+++ b/Sources/Encodable.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016年 tarunon. All rights reserved.
 //
 
+import Foundation
+
 public protocol Encodable {
     func encode() throws -> JSON
 }
@@ -102,3 +104,11 @@ extension ImplicitlyUnwrappedOptional: Encodable {
         }
     }
 }
+
+extension NSString: Encodable {
+    public func encode() throws -> JSON {
+        return .string(self as String)
+    }
+}
+
+extension NSNumber: Number {}

--- a/Sources/Encoder.swift
+++ b/Sources/Encoder.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016年 tarunon. All rights reserved.
 //
 
-//import Foundation
+import Foundation
 
 internal func convert<T>(_ array: [(String, T)]) -> [String: T] {
     var dict = [String: T]()

--- a/Tests/IllusoTests/EncoderTests.swift
+++ b/Tests/IllusoTests/EncoderTests.swift
@@ -15,6 +15,11 @@ private extension Dictionary {
     }
 }
 
+struct SampleNestedEncodableObject: Swift.Encodable {
+    let nestedObject: SampleEncodableObject
+}
+
+extension SampleNestedEncodableObject: Illuso.Encodable { }
 
 struct SampleEncodableObject: Swift.Encodable {
     let floatValue: Float
@@ -41,6 +46,17 @@ class EncoderTests: XCTestCase {
     func testEncodeEncodableToJSON() {
         let object = SampleEncodableObject(floatValue: 1.0, stringValue: "2", intValue: 3)
         let json = try! encode(object).asObject() as! [String: Any]
+        
+        XCTAssertEqual(json["floatValue"] as? Float, 1.0)
+        XCTAssertEqual(json["intValue"] as? Int, 3)
+        XCTAssertEqual(json["stringValue"] as? String, "2")
+    }
+    
+    func testNestedEncodeEncodableToJSON() {
+        let nestedObject = SampleEncodableObject(floatValue: 1.0, stringValue: "2", intValue: 3)
+        let object = SampleNestedEncodableObject(nestedObject: nestedObject)
+        let parentJson = try! encode(object).asObject() as! [String: Any]
+        let json = parentJson["nestedObject"] as! [String: Any]
         
         XCTAssertEqual(json["floatValue"] as? Float, 1.0)
         XCTAssertEqual(json["intValue"] as? Int, 3)

--- a/Tests/IllusoTests/EncoderTests.swift
+++ b/Tests/IllusoTests/EncoderTests.swift
@@ -9,7 +9,53 @@
 import XCTest
 import Illuso
 
+private extension Dictionary {
+    func isEqual(to rhs: [Key: Value]) -> Bool {
+        return NSDictionary(dictionary: self).isEqual(to: rhs)
+    }
+}
+
+
+struct SampleEncodableObject: Swift.Encodable {
+    let floatValue: Float
+    let stringValue: String
+    let intValue: Int
+}
+
+extension SampleEncodableObject: Illuso.Encodable { }
+
 class EncoderTests: XCTestCase {
+    
+    func testEncodeEncodableToDictionary() {
+        let object = SampleEncodableObject(floatValue: 1.0, stringValue: "2", intValue: 3)
+        let expectedDict: [String: Any] = ["floatValue": 1.0, "stringValue": "2", "intValue": 3]
+        let actualDict = try! object.encodeToDictionary()
+        
+        XCTAssertTrue(expectedDict.isEqual(to: actualDict))
+        
+        XCTAssertEqual(actualDict["floatValue"] as? Float, 1.0)
+        XCTAssertEqual(actualDict["stringValue"] as? String, "2")
+        XCTAssertEqual(actualDict["intValue"] as? Float, 3)
+    }
+    
+    func testEncodeEncodableToJSON() {
+        let object = SampleEncodableObject(floatValue: 1.0, stringValue: "2", intValue: 3)
+        let json = try! encode(object).asObject() as! [String: Any]
+        
+        XCTAssertEqual(json["floatValue"] as? Float, 1.0)
+        XCTAssertEqual(json["intValue"] as? Int, 3)
+        XCTAssertEqual(json["stringValue"] as? String, "2")
+    }
+    
+    func testEncodeJsonObject() {
+        let object = SampleEncodableObject(floatValue: 1.0, stringValue: "2", intValue: 3)
+        let jsonObjectData = try! JSONEncoder().encode(object)
+        let jsonObject = try! JSONSerialization.jsonObject(with: jsonObjectData, options: .allowFragments)
+        let json = try! encode(jsonObject).asObject() as! [String: Any]
+        XCTAssertEqual(json["floatValue"] as? Float, 1.0)
+        XCTAssertEqual(json["intValue"] as? Int, 3)
+        XCTAssertEqual(json["stringValue"] as? String, "2")
+    }
     
     func testStandardEncodable() {
         do {


### PR DESCRIPTION
To make migration of the code easier.
Just write follows to conform `Illuso.Encodable`

```swift
struct SampleEncodableObject: Swift.Encodable {
    let floatValue: Float
    let stringValue: String
    let intValue: Int
}

extension SampleEncodableObject: Illuso.Encodable { }
```